### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   test:
     name: Lint
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go Test
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/elfranne/haproxy_runtimeapi_exporter/security/code-scanning/4](https://github.com/elfranne/haproxy_runtimeapi_exporter/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow or the specific job. Since the workflow is only running a release process using GoReleaser, the minimal required permissions are likely `contents: write` (to create releases and upload assets) and possibly `packages: write` (if publishing to GitHub Packages). The safest starting point is to add `permissions` at the job level for `goreleaser`, specifying only the permissions required. This change should be made in `.github/workflows/release.yml`, directly above the `runs-on: ubuntu-latest` line for the `goreleaser` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
